### PR TITLE
Build tcpsecrets for 4.10+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,8 @@ KVER  ?= $(shell uname -r)
 KDIR  ?=  /lib/modules/${KVER}/build
 PWD   := $(shell pwd)
 
-default: system_map.inc
+default:
 	$(MAKE) -C $(KDIR) M=$(PWD) modules
-
-system_map.inc: /boot/System.map-${KVER}
-	@awk '/syncookie_secret/ { printf("#define SYNCOOKIE_SECRET_ADDR 0x%s\n", $$1) }' $< > $@
 
 clean: 
 	@rm -f *.o .*.cmd .*.flags *.mod.c *.order *.ko Module.symvers

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Linux kernel module to provide access to tcp cookie secrets via `/proc/tcp_secre
 - 4.6.0-0.bpo.1-amd64 #1 SMP Debian 4.6.4-1~bpo8+1
 - 4.9.0-0.bpo.3-amd64 #1 SMP Debian 4.9.25-1~bpo8+1
 - 4.9.0-3-amd64 #1 SMP Debian 4.9.30-2+deb9u3
+- 4.9.255 (custom)
+- 5.8.0-48-generic #54~20.04.1-Ubuntu SMP
+- 5.10.24 (custom)
 
 ## Untested kernels
 - 3.16.0-4-amd64 #1 SMP Debian 3.16.36-1+deb8u1 (builds, not tested)
@@ -23,6 +26,12 @@ CONFIG_FTRACE=y
 CONFIG_DYNAMIC_FTRACE=y
 CONFIG_DYNAMIC_FTRACE_WITH_REGS=y
 CONFIG_FTRACE_MCOUNT_RECORD=y
+```
+
+Building for 5.7+ requires kprobes support:
+
+```
+CONFIG_KPROBES=y
 ```
 
 ## Install via DKMS

--- a/tcpsecrets.c
+++ b/tcpsecrets.c
@@ -2,20 +2,37 @@
 #include <linux/module.h>
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
-#include <linux/kallsyms.h>
-#include <linux/cryptohash.h>
 #include <linux/ftrace.h>
 #include <linux/version.h>
 #include <net/tcp.h>
-#include "system_map.inc"
 
-#ifndef SYNCOOKIE_SECRET_ADDR
-#define SYNCOOKIE_SECRET_ADDR 0x0
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
+#define SIPHASH_SYNCOOKIES
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
+#define USE_KPROBES
+#endif
+
+#ifdef SIPHASH_SYNCOOKIES
+#include <linux/siphash.h>
+#else
+#include <linux/cryptohash.h>
+#endif
+
+#ifdef USE_KPROBES
+#include <linux/kprobes.h>
+#else
+#include <linux/kallsyms.h>
 #endif
 
 static void *cookie_v4_check_ptr;
 
-static u32 (*syncookie_secret_ptr)[2][16-4+SHA_DIGEST_WORDS] = (void*)SYNCOOKIE_SECRET_ADDR;
+#ifdef SIPHASH_SYNCOOKIES
+static siphash_key_t (*syncookie_secret_ptr)[2];
+#else
+static u32 (*syncookie_secret_ptr)[2][16-4+SHA_DIGEST_WORDS];
+#endif
 
 static struct proc_dir_entry *proc_entry;
 
@@ -24,9 +41,15 @@ static int tcp_secrets_show(struct seq_file *m, void *v)
 	int i, j;
 	seq_printf(m, "%lu %lu %d\n", (unsigned long) jiffies, (unsigned long)tcp_cookie_time(), HZ);
 	for(i = 0; i < 2; i++) {
-		for(j = 0; j < 16-4+SHA_DIGEST_WORDS; j++) {
-			seq_printf(m, "%.8x.", (*syncookie_secret_ptr)[i][j]); 
+#ifdef SIPHASH_SYNCOOKIES
+		for(j = 0; j < 2; j++) {
+			seq_printf(m, "%.16llx.", (*syncookie_secret_ptr)[i].key[j]);
 		}
+#else
+		for(j = 0; j < 16-4+SHA_DIGEST_WORDS; j++) {
+			seq_printf(m, "%.8x.", (*syncookie_secret_ptr)[i][j]);
+		}
+#endif
         seq_printf(m, "\n");
 	}
 	return 0;
@@ -37,12 +60,22 @@ static int tcp_secrets_open(struct inode *inode, struct file *file)
 	return single_open(file, tcp_secrets_show, NULL);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
+static const struct proc_ops tcp_secrets_fops = {
+	.proc_open		= tcp_secrets_open,
+	.proc_read		= seq_read,
+	.proc_lseek		= seq_lseek,
+	.proc_release	= single_release,
+};
+#else
 static const struct file_operations tcp_secrets_fops = {
 	.open		= tcp_secrets_open,
 	.read		= seq_read,
 	.llseek		= seq_lseek,
 	.release	= single_release,
 };
+#endif
+
 static int symbol_walk_callback(void *data, const char *name,
 				struct module *mod, unsigned long addr) {
 	if (mod)
@@ -57,6 +90,43 @@ static int symbol_walk_callback(void *data, const char *name,
 	return 0;
 }
 
+#ifdef USE_KPROBES
+static int (*kallsyms_on_each_symbol_ptr)(int (*fn)(void *, const char *,
+                                                 struct module *,
+                                                 unsigned long),
+                                       void *data);
+
+typedef unsigned long (*kallsyms_lookup_name_t)(const char *name);
+
+static int dummy_kprobe_handler(struct kprobe *p, struct pt_regs *regs) {
+	return 0;
+}
+
+static kallsyms_lookup_name_t get_kallsyms_lookup_name_ptr(void) {
+	struct kprobe probe;
+	int ret;
+	kallsyms_lookup_name_t addr;
+
+	memset(&probe, 0, sizeof(probe));
+	probe.pre_handler = dummy_kprobe_handler;
+	probe.symbol_name = "kallsyms_lookup_name";
+	ret = register_kprobe(&probe);
+	if (ret)
+		return NULL;
+	addr = (kallsyms_lookup_name_t) probe.addr;
+	unregister_kprobe(&probe);
+
+	return addr;
+}
+
+static unsigned long lookup_name(const char *name) {
+	static kallsyms_lookup_name_t func_ptr = NULL;
+	if (!func_ptr)
+		func_ptr = get_kallsyms_lookup_name_ptr();
+
+	return func_ptr(name);
+}
+#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,18,0)
 static struct sock *cookie_v4_check_wrapper(struct sock *sk,
@@ -117,11 +187,30 @@ static void fix_cookie_v4_check(void) {
 	}
 }
 
+#ifdef SIPHASH_SYNCOOKIES
+static void init_secrets(void)
+{
+	struct iphdr ip;
+	struct tcphdr tcp;
+	u16 mssp;
+
+	__cookie_v4_init_sequence(&ip, &tcp, &mssp);
+}
+#endif
+
 static int __init tcp_secrets_init(void)
 {
-	int rc = kallsyms_on_each_symbol(symbol_walk_callback, NULL);
-	if (rc)
+	int rc;
+#ifndef USE_KPROBES
+	rc = kallsyms_on_each_symbol(symbol_walk_callback, NULL);
+#else
+	kallsyms_on_each_symbol_ptr = (void *) lookup_name("kallsyms_on_each_symbol");
+	rc = kallsyms_on_each_symbol_ptr(symbol_walk_callback, NULL);
+#endif
+	if (rc) {
 		return rc;
+	}
+
 	if (cookie_v4_check_ptr) {
 		fix_cookie_v4_check();
 	} else {
@@ -132,7 +221,18 @@ static int __init tcp_secrets_init(void)
 		printk("tcp_secrets: can't find syncookie secret!\n");
 		return -2;
 	}
-	return (proc_entry = proc_create("tcp_secrets", 0, NULL, &tcp_secrets_fops)) == NULL;
+
+	proc_entry = proc_create("tcp_secrets", 0, NULL, &tcp_secrets_fops);
+	if (proc_entry == NULL) {
+		printk("tcp_secrets: can't create proc entry!\n");
+		return -3;
+	}
+
+#ifdef SIPHASH_SYNCOOKIES
+	init_secrets();
+#endif
+
+	return 0;
 }
 
 module_init(tcp_secrets_init);
@@ -162,4 +262,4 @@ module_exit(tcp_secrets_exit);
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Alexander Polyakov <apolyakov@beget.ru>");
 MODULE_DESCRIPTION("Provide access to tcp syncookie secrets via /proc/tcp_secrets");
-MODULE_VERSION("1.1");
+MODULE_VERSION("1.2");


### PR DESCRIPTION
The most noteworthy changes are:
1. Expose SipHash secrets on 4.10+
   SipHash is used for syncookie generation since torvalds/linux@fe62d05b
   The tricky part is to trigger secrets generation at startup
   (see ddos-mitigator/tcpsecrets@fe22ff3 for a more complex implementation)

2. Lookup kernel symbols with kprobes on 5.7+
   `kallsyms_on_each_symbol` is no longer exported since torvalds/linux@0bd476e6,
   therefore we have to find another approach for accessing kernel internals.
   Using kprobes seems to be an appropriate solution since
   `CONFIG_KPROBES` usually defaults to 'yes'.
   The idea was borrowed from choff/anbox-modules@4af9d5d
   (which is believed to be inspired by lttng/lttng-modules@a657654)

Other changes and fixes:
- Handle procfs API update: file_operations -> proc_ops
- Remove obsolete System.map parser thing
- Update tested kernels list